### PR TITLE
HB-6739: Add base privacy manifest

### DIFF
--- a/ChartboostMediationAdapterMobileFuse.podspec
+++ b/ChartboostMediationAdapterMobileFuse.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   # Source
   spec.module_name  = 'ChartboostMediationAdapterMobileFuse'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-mobilefuse.git', :tag => spec.version }
+  spec.resource_bundles = { 'ChartboostMediationAdapterMobileFuse' => ['PrivacyInfo.xcprivacy'] }
   spec.source_files = 'Source/**/*.{swift}'
 
   # Minimum supported versions

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Source/MobileFuseAdapter.swift
+++ b/Source/MobileFuseAdapter.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/MobileFuseAdapterAd.swift
+++ b/Source/MobileFuseAdapterAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/MobileFuseAdapterBannerAd.swift
+++ b/Source/MobileFuseAdapterBannerAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/MobileFuseAdapterConfiguration.swift
+++ b/Source/MobileFuseAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/MobileFuseAdapterInterstitialAd.swift
+++ b/Source/MobileFuseAdapterInterstitialAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.

--- a/Source/MobileFuseAdapterRewardedAd.swift
+++ b/Source/MobileFuseAdapterRewardedAd.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2023 Chartboost, Inc.
+// Copyright 2023-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6739

For the MobileFuse adapter, the privacy manifest can be bare-bones.