### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/MobileFuseAdapter.swift
+++ b/Source/MobileFuseAdapter.swift
@@ -15,18 +15,26 @@ final class MobileFuseAdapter: PartnerAdapter {
     // MARK: PartnerAdapter
 
     /// The version of the partner SDK.
-    let partnerSDKVersion = MobileFuse.version() ?? ""
+    var partnerSDKVersion: String {
+        MobileFuseAdapterConfiguration.partnerSDKVersion
+    }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.1.7.0.0"
+    var adapterVersion: String {
+        MobileFuseAdapterConfiguration.adapterVersion
+    }
 
     /// The partner's unique identifier.
-    let partnerID = "mobilefuse"
+    var partnerID: String {
+        MobileFuseAdapterConfiguration.partnerID
+    }
 
     /// The human-friendly partner name.
-    let partnerDisplayName = "MobileFuse"
+    var partnerDisplayName: String {
+        MobileFuseAdapterConfiguration.partnerDisplayName
+    }
 
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.

--- a/Source/MobileFuseAdapterConfiguration.swift
+++ b/Source/MobileFuseAdapterConfiguration.swift
@@ -9,20 +9,20 @@ import MobileFuseSDK
 @objc public class MobileFuseAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         MobileFuse.version() ?? ""
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.1.7.0.0"
+    @objc public static let adapterVersion = "4.1.7.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "mobilefuse"
+    @objc public static let partnerID = "mobilefuse"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "MobileFuse"
+    @objc public static let partnerDisplayName = "MobileFuse"
 
     /// Flag that can optionally be set to enable the partner's test mode.
     /// Disabled by default.

--- a/Source/MobileFuseAdapterConfiguration.swift
+++ b/Source/MobileFuseAdapterConfiguration.swift
@@ -4,8 +4,25 @@
 // license that can be found in the LICENSE file.
 
 import Foundation
+import MobileFuseSDK
 
 @objc public class MobileFuseAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        MobileFuse.version() ?? ""
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.1.7.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "mobilefuse"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "MobileFuse"
 
     /// Flag that can optionally be set to enable the partner's test mode.
     /// Disabled by default.


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.