### PR TITLE
Update MobileFuse SDK to 1.8.0 for Mediation 4 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.1.8.0.0
+- This version of the adapter has been certified with MobileFuseSDK 1.8.0.
+
 ### 4.1.7.0.0
 - This version of the adapter has been certified with MobileFuseSDK 1.7.0.
 

--- a/ChartboostMediationAdapterMobileFuse.podspec
+++ b/ChartboostMediationAdapterMobileFuse.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterMobileFuse'
-  spec.version     = '4.1.7.0.0'
+  spec.version     = '4.1.8.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-mobilefuse'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'MobileFuseSDK', '~> 1.7.0'
+  spec.dependency 'MobileFuseSDK', '~> 1.8.0'
 
   # Indicates, that if use_frameworks! is specified, the pod should include a static library framework.
   spec.static_framework = true

--- a/Source/MobileFuseAdapter.swift
+++ b/Source/MobileFuseAdapter.swift
@@ -20,7 +20,7 @@ final class MobileFuseAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.1.7.0.0"
+    let adapterVersion = "4.1.8.0.0"
 
     /// The partner's unique identifier.
     let partnerIdentifier = "mobilefuse"


### PR DESCRIPTION
This updates the adapter to support MobileFuse SDK 1.8.0 for Mediation 4 SDK.

DO NOT MERGE